### PR TITLE
messages css & infinite loading chats fix

### DIFF
--- a/frontend/src/components/MyChats.js
+++ b/frontend/src/components/MyChats.js
@@ -11,6 +11,7 @@ function MyChats({ fetchAgain }) {
   const { user, selectedChat, setSelectedChat, chats, setChats } = ChatState();
 
   const [loggedUser, setLoggedUser] = useState(user);
+  const [loading, setLoading] = useState(true);
 
   const toast = useToast();
 
@@ -23,6 +24,7 @@ function MyChats({ fetchAgain }) {
       };
 
       const { data } = await axios.get("/api/chat", config);
+      setLoading(false);
 
       setChats(data);
     } catch (error) {
@@ -41,6 +43,10 @@ function MyChats({ fetchAgain }) {
     setLoggedUser(JSON.parse(localStorage.getItem("userInfo")));
     fetchChats();
   }, [fetchAgain]);
+
+  useEffect(() => {
+    setTimeout(() => setLoading(false), 10000);
+  }, []);
 
   return (
     <Box
@@ -85,6 +91,10 @@ function MyChats({ fetchAgain }) {
         borderRadius="lg"
         overflowY="hidden"
       >
+        {/**
+         * When no chats: Show skeleton if loading else No Chats Message after 10s
+         * When Chats: Show Chats
+         */}
         {chats.length > 0 ? (
           <Stack overflowY="scroll">
             {chats.map((chat) => (
@@ -106,8 +116,14 @@ function MyChats({ fetchAgain }) {
               </Box>
             ))}
           </Stack>
-        ) : (
+        ) : loading ? (
           <ChatLoading />
+        ) : (
+          <div>
+            <h1 style={{ textAlign: "center", fontSize: "1.5rem" }}>
+              You do not have any chats
+            </h1>
+          </div>
         )}
       </Box>
     </Box>

--- a/frontend/src/config/ChatLogics.js
+++ b/frontend/src/config/ChatLogics.js
@@ -38,7 +38,7 @@ export const isSameSenderMargin = (messages, m, i, userId) => {
   // sender same as next message && is not the loggedin user, set margin to 33 (to align with dp width)
   if (
     i < messages.length - 1 &&
-    messages[i + 1].sender._id === m.sender.id &&
+    messages[i + 1].sender._id === m.sender._id &&
     messages[i].sender._id !== userId
   )
     return 33;


### PR DESCRIPTION
- `frontend/src/components/MyChats.js` : When no chats available for user, showing skeleton for infinite time. Fixed.
- `frontend/src/config/ChatLogics.js` : Updated messages margin logic